### PR TITLE
✨ Display weapon's skill stats change

### DIFF
--- a/src/data/weapons/guns/primary.ts
+++ b/src/data/weapons/guns/primary.ts
@@ -12,8 +12,8 @@ const primary = {
 	'Shotgun': shotgunsPrimary,
 	'LMG': lightMachineGuns,
 	'Sniper': snipersPrimary,
-	// 'Akimbo Pistol': [],
-	// 'Akimbo SMG': [],
+	'Akimbo Pistol': {},
+	'Akimbo SMG': {},
 	'Akimbo Shotgun': akimboShotguns,
 	'Special': specialsPrimary
 }

--- a/src/hooks/useWeaponStats.ts
+++ b/src/hooks/useWeaponStats.ts
@@ -1,4 +1,5 @@
 import { type ModificationSlot, type ModificationStats, type WeaponData, type WeaponStats } from 'data/weapons/guns/weaponTypes'
+import { useSkillsStore } from 'state/useSkillsStore'
 import { typedObject } from 'utils/typedObject'
 
 interface UseWeaponStats {
@@ -28,6 +29,25 @@ const useWeaponStats = (weaponData: WeaponData, weaponModifications: Partial<Rec
 		return ({ ...weaponData.stats, ...extraStats })
 	}
 
+	const skillTrees = useSkillsStore(state => state.trees)
+
+	const stableShot = skillTrees.mastermind.Sharpshooter.upgrades['Stable Shot']
+	// const marksman = skillTrees.mastermind.Sharpshooter.upgrades['Marksman']
+	// const aggressiveReload = skillTrees.mastermind.Sharpshooter.upgrades['Aggressive Reload']
+	// const shotgunCBQ = skillTrees.enforcer.Shotgunner.upgrades['Shotgun CBQ']
+	const shotgunImpact = skillTrees.enforcer.Shotgunner.upgrades['Shotgun Impact']
+	// const closeBy = skillTrees.enforcer.Shotgunner.upgrades['Close By']
+	const fullyLoaded = skillTrees.enforcer['Ammo Specialist'].upgrades['Fully Loaded']
+	const steadyGrip = skillTrees.technician.Oppressor.upgrades['Steady Grip']
+	const surefire = skillTrees.technician.Oppressor.upgrades['Surefire']
+	const opticalIllusions = skillTrees.ghost['Silent Killer'].upgrades['Optical Illusions']
+	const theProfessional = skillTrees.ghost['Silent Killer'].upgrades['The Professional']
+	const equilibrium = skillTrees.fugitive.Gunslinger.upgrades['Equilibrium']
+	const gunNut = skillTrees.fugitive.Gunslinger.upgrades['Gun Nut']
+	const akimbo = skillTrees.fugitive.Gunslinger.upgrades['Akimbo']
+	const oneHandedTalent = skillTrees.fugitive.Gunslinger.upgrades['One Handed Talent']
+	// const desperado = skillTrees.fugitive.Gunslinger.upgrades['Desperado']
+
 	const skillStats = (): WeaponStats => {
 		const baseStats: WeaponStats = {
 			totalAmmo: 0,
@@ -40,6 +60,109 @@ const useWeaponStats = (weaponData: WeaponData, weaponModifications: Partial<Rec
 			threat: 0,
 			rateOfFire: 0
 		}
+
+		// Stable Shot
+		baseStats.stability += stableShot === 'basic' || stableShot === 'aced' ? 8 : 0
+
+		// Marksman
+		// TODO: check a weapon has only single fire mode
+		// if (weaponData.weaponType === 'Assault Rifle' || weaponData.weaponType === 'Submachine Gun' || weaponData.weaponType === 'Sniper') {
+		//  baseStats.accuracy += marksman === 'basic' || marksman === 'aced' ? 8 : 0
+		// }
+
+		// Shotgun Impact
+		if (weaponData.weaponType === 'Akimbo Shotgun' || weaponData.weaponType === 'Shotgun') {
+			baseStats.accuracy += shotgunImpact === 'basic' || shotgunImpact === 'aced' ? 8 : 0
+			baseStats.damage += shotgunImpact === 'basic' || shotgunImpact === 'aced' ? weaponData.stats.damage * 0.05 : 0
+			baseStats.damage += shotgunImpact === 'aced' ? weaponData.stats.damage * 0.1 : 0
+		}
+
+		// Close By
+		// TODO: check shotguns have magazines
+		// if (weaponData.weaponType === 'Akimbo Shotgun') {
+		// 	baseStats.magazine += closeBy === 'aced' ? 30 : 0
+		// }
+		// if (weaponData.weaponType === 'Shotgun') {
+		// 	baseStats.magazine += closeBy === 'aced' ? 15 : 0
+		// }
+
+		// Fully Loaded
+		baseStats.totalAmmo += fullyLoaded === 'basic' || fullyLoaded === 'aced' ? (weaponData.stats.totalAmmo + baseStats.totalAmmo) * 0.25 : 0
+
+		// Steady Grip
+		baseStats.accuracy += steadyGrip === 'basic' || steadyGrip === 'aced' ? 8 : 0
+		baseStats.stability += steadyGrip === 'aced' ? 16 : 0
+
+		// Surefire
+		if (weaponData.weaponType === 'Submachine Gun' || weaponData.weaponType === 'LMG' || weaponData.weaponType === 'Assault Rifle') {
+			baseStats.magazine += surefire === 'basic' || surefire === 'aced' ? 15 : 0
+		}
+		if (weaponData.weaponType === 'Akimbo SMG') {
+			baseStats.magazine += surefire === 'basic' || surefire === 'aced' ? 30 : 0
+		}
+
+		const findSilencer = () => {
+			if (weaponModifications.barrel) {
+				const barrel = weaponData.modifications.barrel?.find(barrel => barrel.name === weaponModifications.barrel)
+				if (barrel && barrel.specialEffect && barrel.specialEffect[0] === 'Silences Weapon') {
+					return barrel
+				}
+			}
+			if (weaponModifications.barrelExt) {
+				const barrelExt = weaponData.modifications.barrelExt?.find(barrelExt => barrelExt.name === weaponModifications.barrelExt)
+				if (barrelExt && barrelExt.specialEffect && barrelExt.specialEffect[0] === 'Silences Weapon') {
+					return barrelExt
+				}
+			}
+		}
+		const silencer = findSilencer()
+
+		// Optical Illusions
+		if (silencer && silencer.slot === 'barrelExt') {
+			if (silencer.stats.concealment && silencer.stats.concealment < 0) {
+				baseStats.concealment += opticalIllusions === 'aced' ? Math.abs(Math.max(silencer.stats.concealment, -2)) : 0
+			}
+			baseStats.concealment += opticalIllusions === 'aced' ? 1 : 0
+		}
+
+		// The Professional
+		if (silencer) {
+			baseStats.stability += theProfessional === 'basic' || theProfessional === 'aced' ? 8 : 0
+			baseStats.accuracy += theProfessional === 'aced' ? 12 : 0
+		}
+
+		// Equilibrium
+		if (weaponData.weaponType === 'Pistol' || weaponData.weaponType === 'Akimbo Pistol') {
+			baseStats.accuracy += equilibrium === 'aced' ? 8 : 0
+		}
+
+		// Gun Nut
+		if (weaponData.weaponType === 'Pistol') {
+			baseStats.magazine += gunNut === 'basic' || gunNut === 'aced' ? 5 : 0
+			baseStats.rateOfFire += gunNut === 'aced' ? weaponData.stats.rateOfFire / 2 : 0
+		}
+		if (weaponData.weaponType === 'Akimbo Pistol') {
+			baseStats.magazine += gunNut === 'basic' || gunNut === 'aced' ? 10 : 0
+			baseStats.rateOfFire += gunNut === 'aced' ? weaponData.stats.rateOfFire / 2 : 0
+		}
+
+		// Akimbo
+		if (weaponData.weaponType === 'Akimbo Pistol' || weaponData.weaponType === 'Akimbo SMG' || weaponData.weaponType === 'Akimbo Shotgun') {
+			baseStats.accuracy += akimbo === 'basic' || akimbo === 'aced' ? 8 : 0
+			baseStats.accuracy += akimbo === 'aced' ? 8 : 0
+			baseStats.totalAmmo += akimbo === 'aced' ? (weaponData.stats.totalAmmo + baseStats.totalAmmo) * 0.5 : 0
+		}
+
+		// One Handed Talent
+		if (weaponData.weaponType === 'Pistol' || weaponData.weaponType === 'Akimbo Pistol') {
+			baseStats.damage += oneHandedTalent === 'basic' || oneHandedTalent === 'aced' ? 5 : 0
+			baseStats.damage += oneHandedTalent === 'aced' ? 10 : 0
+		}
+
+		// TODO: Find reload speed calculating formula
+		// Aggresive Reload
+		// Shotgun CBQ
+		// Desperado
 
 		return baseStats
 	}


### PR DESCRIPTION
`skillStats` values in` WeaponStats.ts` are currently fixed at 0.
So I added logic to calculate `skillStats` in `useWeaponStats.ts` according to the skills you have.
Skills that affect weapon stats are as follows:

### Done
- [x] Stable Shot
- [x] Shotgun Impact
- [x] Fully Loaded
- [x] Steady Grip
- [x] Surefire
- [x] Optical Illusions
- [x] The Professional
- [x] Equilibrium
- [x] Gun Nut
- [x] Akimbo
- [x] One Handed Talent

### Todo
- [ ] Marksman

Need logic to check if it is a weapon that only has single fire mode
(If it's a weapon with only single fire mode, like Galant or sniper rifles, this skill increases accuracy)

-  [ ] Close By

Need logic to check if it is a shotgun with magazines

- [ ] Aggresive Reload
- [ ] Shotgun CBQ
- [ ] Desperado

I couldn't find the exact formula for calculating the reload speed, so the skills that affect reload speed were left as todo.

Sorry for not writing issue before PR.
